### PR TITLE
drop deprecated style attribute

### DIFF
--- a/icons/tents.svg
+++ b/icons/tents.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 48 48" xml:space="preserve">
   <path d="M45.7 12.7c-0.1 -0.4 -0.3 -0.8 -0.6 -1L30.5 0.3c-0.6 -0.4 -1.4 -0.4 -2 0L13.9 11.7c-0.3 0.2 -0.5 0.6 -0.6 1l-0.8 5.7l3.1 -2.4c1.7 -1.3 4 -1.3 5.7 0l5.7 4.4l2 1.5l2.7 2.1l1.3 1l2.9 2.3c0.9 0.7 1.5 1.6 1.7 2.7H48L45.7 12.7z"/>
   <path d="M34.1 29.7L29 25.7L28.1 25L27 24.2l-7.5 -5.8c-0.3 -0.2 -0.6 -0.3 -1 -0.3c-0.4 0 -0.7 0.1 -1 0.3L12 22.6l-9.1 7c-0.3 0.2 -0.5 0.6 -0.6 1L0 48h18v-9.7c0 -0.2 0.1 -0.3 0.3 -0.3c0 0 0 0 0 0c0.1 0 0.2 0.1 0.3 0.1L24 48h13l-2.3 -17.3C34.6 30.3 34.4 29.9 34.1 29.7z"/>
 </svg>


### PR DESCRIPTION
The [`enable-background`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/enable-background) style attribute is deprecated and seems to not be relevant for this icon set if I'm not mistaken.